### PR TITLE
Corrige erro em listarContatos()

### DIFF
--- a/agenda.pl
+++ b/agenda.pl
@@ -88,7 +88,7 @@ sw(9):-
 sw(10):-
 	write("Nome: "), read(NOME), nl,
 	verificaContato(NOME),
-	exibirContatosNomeComum(NOME),
+	exibirContatosNomeBloqueado(NOME),
 	write('Digite o número para confirmar: '), read(NUMERO),
 	desbloquearContato(NOME, NUMERO).
 
@@ -225,8 +225,8 @@ verificaContato(NOME):-
 	executaMenu().
 
 exibirContatosNomeComum(NOME):-
-	forall(contato(NOME,Y), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y]));
-
+	forall(contato(NOME,Y), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y])).
+exibirContatosNomeBloqueado(NOME):-
 	forall(bloqueado(contato(NOME,Y)), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y])).
 
 %------------Adicionar um contato aos favoritos-----------------------------------------------------

--- a/agenda.pl
+++ b/agenda.pl
@@ -29,8 +29,8 @@ sw(1):-
 
 sw(2):-
 	write('*:･ﾟ✧*:･ﾟ✧ Seus Contatos *:･ﾟ✧*:･ﾟ✧'),nl,nl,
-	findall(X, (contato(X,_)),L),
-	exibeContatos(L).
+	forall(contato(X,Y), format('Nome: ~w~nNumero: ~w~n~n', [X,Y])),
+	executaMenu().
 
 sw(3):-
 	write("Nome: "),read(NOME),nl,

--- a/agenda.pl
+++ b/agenda.pl
@@ -71,7 +71,9 @@ sw(8):-
 	write('Digite o nome do contato que deseja alterar: '),
 	read(NOMEANTIGO),nl,
 	verificaContato(NOMEANTIGO),
-	alteraContato(NOMEANTIGO),
+	exibirContatosNomeComum(NOME),
+	write('Digite o número para confirmar: '), read(NUMERO),
+	alteraContato(NOMEANTIGO, NUMERO),
 	executaMenu().
 
 sw(9):-
@@ -157,45 +159,45 @@ apagaContato(NOME,NUMERO):-
 %-------------Método que altera o fato contato da base de dados ------------------
 
 
-alteraContato(NOMEANTIGO):- 
+alteraContato(NOMEANTIGO, NUMERO):- 
 	alterarContatoMenu(),
 	read(OP),nl,
-	subMenuAlteraContato(OP,NOMEANTIGO).
+	subMenuAlteraContato(OP,NOMEANTIGO,NUMERO).
 	
-subMenuAlteraContato(1,NomeAntigo):- 
+subMenuAlteraContato(1,NomeAntigo,NUMERO):- 
 	write("digite o novo nome:"),
 	read(NovoNome),nl,
 	
-	contato(NomeAntigo,X),
-	alteraBloqueado(NomeAntigo,NovoNome,X),
-	chamar(contato(NomeAntigo,_),CHAMADAS),
-	retract(chamar(contato(NomeAntigo,_),_)),
+	contato(NomeAntigo,NUMERO),
+	alteraBloqueado(NomeAntigo,NovoNome,NUMERO),
+	chamar(contato(NomeAntigo,NUMERO),CHAMADAS),
+	retract(chamar(contato(NomeAntigo,NUMERO),_)),
 
-	apagaContato(NomeAntigo,X),
-	adicionaContato(NovoNome, X,CHAMADAS),
+	apagaContato(NomeAntigo,NUMERO),
+	adicionaContato(NovoNome, NUMERO,CHAMADAS),
 	write("Nome alterado com sucesso!"),nl,nl.
 	
 	
-subMenuAlteraContato(2,NomeAntigo):- 
+subMenuAlteraContato(2,NomeAntigo,NUMERO):- 
 	write("digite o novo número:"),
 	read(NovoNumero),nl,
 
-	apagaContato(NomeAntigo,X),
+	apagaContato(NomeAntigo,NUMERO),
 	assertz(contato(NomeAntigo,NovoNumero)),
 
 	write("Numero alterado com sucesso!"),nl,nl.
 	
-subMenuAlteraContato(3,NomeAntigo):- 
+subMenuAlteraContato(3,NomeAntigo,NUMERO):- 
 	write("digite o novo nome:"),
 	read(NovoNome),nl,
 	write("digite o novo número:"),
 	read(NovoNumero),nl,
 
-	contato(NomeAntigo,_),
-	chamar(contato(NomeAntigo,_),CHAMADAS),
-	retract(chamar(contato(NomeAntigo,_),_)),
+	contato(NomeAntigo,NUMERO),
+	chamar(contato(NomeAntigo,NUMERO),CHAMADAS),
+	retract(chamar(contato(NomeAntigo,NUMERO),_)),
 	alteraBloqueado(NomeAntigo,NovoNome,NovoNumero),
-	apagaContato(NomeAntigo,X),
+	apagaContato(NomeAntigo,NUMERO),
 	adicionaContato(NovoNome, NovoNumero,CHAMADAS),
 
 	write("Nome e número alterados com sucesso!"),nl,nl.

--- a/agenda.pl
+++ b/agenda.pl
@@ -65,7 +65,9 @@ sw(6):-
 sw(7):-
 	write("Nome: "), read(NOME), nl,
 	verificaContato(NOME),
-	adicionarAosFavoritos(NOME).
+	exibirContatosNomeComum(NOME),
+	write('Digite o número para confirmar: '), read(NUMERO),
+	adicionarAosFavoritos(NOME,NUMERO).
 
 sw(8):-
 	write('Digite o nome do contato que deseja alterar: '),
@@ -99,10 +101,14 @@ sw(12):-
 	write('*:･ﾟ✧*:･ﾟ✧ (ღ˘⌣˘ღ)  Contatos favoritos  (ღ˘⌣˘ღ) *:･ﾟ✧*:･ﾟ✧'),nl,nl,
 	findall(X, (favorito(X)), L),
 	listarContatos(L).
+
 sw(13):-
 	write("Nome: "), read(NOME), nl,
 	verificaContato(NOME),
-	removerFavorito(NOME).
+	exibirContatosNomeComum(NOME),
+	write('Digite o número para confirmar: '), read(NUMERO),
+
+	removerFavorito(NOME,NUMERO).
 
 sw(14):-
 	menuGrupo(),
@@ -224,22 +230,22 @@ exibirContatosNomeComum(NOME):-
 	forall(bloqueado(contato(NOME,Y)), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y])).
 
 %------------Adicionar um contato aos favoritos-----------------------------------------------------
-adicionarAosFavoritos(NOME):-
-	call(favorito(contato(NOME,_))), !,
+adicionarAosFavoritos(NOME,NUMERO):-
+	call(favorito(contato(NOME,NUMERO))), !,
 	write("Contato já está na sua lista de favoritos :)"), nl,nl,
 	executaMenu;
 
-	contato(NOME,X),
-	assertz(favorito(contato(NOME,X))),
+	contato(NOME,NUMERO),
+	assertz(favorito(contato(NOME,NUMERO))),
 	write("Contato adicionado aos favoritos com sucesso!"),nl,nl,
 	executaMenu().
 
 
 %------------Remover um contato da lista de favoritos-----------------------------------------------------
-removerFavorito(NOME):-
-	call(favorito(contato(NOME,X))), !,
-	apagaContato(NOME),
-	adicionaContato(NOME, X),
+removerFavorito(NOME,NUMERO):-
+	call(favorito(contato(NOME,NUMERO))), !,
+	apagaContato(NOME,NUMERO),
+	adicionaContato(NOME, NUMERO, CHAMADAS),
 	write("Contato removido da lista de favoritos!"),nl,nl,
 	executaMenu(), nl;
 

--- a/agenda.pl
+++ b/agenda.pl
@@ -83,7 +83,9 @@ sw(9):-
 sw(10):-
 	write("Nome: "), read(NOME), nl,
 	verificaContato(NOME),
-	desbloquearContato(NOME).
+	exibirContatosNomeComum(NOME),
+	write('Digite o número para confirmar: '), read(NUMERO),
+	desbloquearContato(NOME, NUMERO).
 
 sw(11):-
 	write('*:･ﾟ✧*:･ﾟ✧ 	ψ(｀∇´)ψ  Contatos bloqueados  	ψ(｀∇´)ψ  *:･ﾟ✧*:･ﾟ✧'),nl,nl,
@@ -204,11 +206,15 @@ alteraBloqueado(Nome,NovoNome,Numero):-
 verificaContato(NOME):-
 	call(contato(NOME,_)), !;
 
+	call(bloqueado(contato(NOME,_))), !;
+
 	write("Contato nao existe!"), nl,nl,
 	executaMenu().
 
 exibirContatosNomeComum(NOME):-
-	forall(contato(NOME,Y), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y])).
+	forall(contato(NOME,Y), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y]));
+
+	forall(bloqueado(contato(NOME,Y)), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y])).
 
 %------------Adicionar um contato aos favoritos-----------------------------------------------------
 adicionarAosFavoritos(NOME):-
@@ -258,10 +264,10 @@ listarContatos([contato(X,Y)|Tail]):-
 
 %--------Desbloquear contato-------------------------------------------------
 
-desbloquearContato(NOME):-
-	call(bloqueado(contato(NOME,X))), !,
-	apagaContato(NOME),
-	adicionaContato(NOME,X),
+desbloquearContato(NOME,NUMERO):-
+	call(bloqueado(contato(NOME,NUMERO))), !,
+	retract(bloqueado(contato(NOME,NUMERO))),
+	assertz(contato(NOME,NUMERO)),
 	write("Contato desbloqueado!"), nl, nl,
 	executaMenu(), nl;
 

--- a/agenda.pl
+++ b/agenda.pl
@@ -73,6 +73,7 @@ sw(8):-
 	verificaContato(NOMEANTIGO),
 	alteraContato(NOMEANTIGO),
 	executaMenu().
+
 sw(9):-
 	write("Nome: "), read(NOME), nl,
 	verificaContato(NOME),
@@ -93,7 +94,7 @@ sw(11):-
 	listarContatos(L).
 
 sw(12):-
-		write('*:･ﾟ✧*:･ﾟ✧ (ღ˘⌣˘ღ)  Contatos favoritos  (ღ˘⌣˘ღ) *:･ﾟ✧*:･ﾟ✧'),nl,nl,
+	write('*:･ﾟ✧*:･ﾟ✧ (ღ˘⌣˘ღ)  Contatos favoritos  (ღ˘⌣˘ღ) *:･ﾟ✧*:･ﾟ✧'),nl,nl,
 	findall(X, (favorito(X)), L),
 	listarContatos(L).
 sw(13):-
@@ -170,7 +171,7 @@ subMenuAlteraContato(1,NomeAntigo):-
 	chamar(contato(NomeAntigo,_),CHAMADAS),
 	retract(chamar(contato(NomeAntigo,_),_)),
 
-	apagaContato(NomeAntigo),
+	apagaContato(NomeAntigo,X),
 	adicionaContato(NovoNome, X,CHAMADAS),
 	write("Nome alterado com sucesso!"),nl,nl.
 	
@@ -178,8 +179,10 @@ subMenuAlteraContato(1,NomeAntigo):-
 subMenuAlteraContato(2,NomeAntigo):- 
 	write("digite o novo número:"),
 	read(NovoNumero),nl,
-	apagaContato(NomeAntigo),
+
+	apagaContato(NomeAntigo,X),
 	assertz(contato(NomeAntigo,NovoNumero)),
+
 	write("Numero alterado com sucesso!"),nl,nl.
 	
 subMenuAlteraContato(3,NomeAntigo):- 
@@ -187,12 +190,14 @@ subMenuAlteraContato(3,NomeAntigo):-
 	read(NovoNome),nl,
 	write("digite o novo número:"),
 	read(NovoNumero),nl,
+
 	contato(NomeAntigo,_),
 	chamar(contato(NomeAntigo,_),CHAMADAS),
 	retract(chamar(contato(NomeAntigo,_),_)),
 	alteraBloqueado(NomeAntigo,NovoNome,NovoNumero),
-	apagaContato(NomeAntigo),
+	apagaContato(NomeAntigo,X),
 	adicionaContato(NovoNome, NovoNumero,CHAMADAS),
+
 	write("Nome e número alterados com sucesso!"),nl,nl.
 
 alteraBloqueado(Nome,NovoNome,Numero):-

--- a/agenda.pl
+++ b/agenda.pl
@@ -76,7 +76,9 @@ sw(8):-
 sw(9):-
 	write("Nome: "), read(NOME), nl,
 	verificaContato(NOME),
-	bloqueiaContato(NOME).
+	exibirContatosNomeComum(NOME),
+	write('Digite o número para confirmar: '), read(NUMERO),
+	bloqueiaContato(NOME,NUMERO).
 
 sw(10):-
 	write("Nome: "), read(NOME), nl,
@@ -232,18 +234,19 @@ removerFavorito(NOME):-
 	executaMenu().
 %------------Bloqueia contato-----------------------------------------------------
 
-bloqueiaContato(NOME):-
-	call(bloqueado(contato(NOME,_))), !,
+bloqueiaContato(NOME, NUMERO):-
+	call(bloqueado(contato(NOME,NUMERO))), !,
 	write("Contato já está bloqueado!"), nl,nl,
 	executaMenu();
 
-	contato(NOME,X),
-	assertz(bloqueado(contato(NOME,X))),
+	assertz(bloqueado(contato(NOME,NUMERO))),
+	retract(contato(NOME,NUMERO)),
 	write("Contato bloqueado com sucesso!"),nl,nl,
 	executaMenu().
 
 
 %---------Printa uma lista de contatos----------------------------------------
+
 
 listarContatos([]):-
 	executaMenu().
@@ -286,8 +289,6 @@ verificaFavorito(Nome,5):-call(favorito(contato(Nome,_))), !;contato(Nome,X),
 
 exibeContatoss([]).
 exibeContatoss([Head|Tail]):-
-
-
 	write(Head),nl,
 	
 	exibeContatos(Tail).

--- a/agenda.pl
+++ b/agenda.pl
@@ -35,7 +35,9 @@ sw(2):-
 sw(3):-
 	write("Nome: "),read(NOME),nl,
 	verificaContato(NOME), %se o contato nao existe, executa menu de novo
-	apagaContato(NOME),
+	exibirContatosNomeComum(NOME),
+	write('Digite o número para confirmar: '), read(NUMERO),
+	apagaContato(NOME,NUMERO),
 
 	write("Contato apagado com sucesso! ヽ(ﾟｰ ﾟ*ヽ) "), nl, nl,
 	executaMenu().
@@ -136,16 +138,16 @@ buscarContato(NOME,NUMERO):-
 
 % ------------Método que apaga fato contato(NOME, _) da base de dados.------------
 
-apagaContato(NOME):-
-	call(bloqueado(contato(NOME,_))), !,
-	retract(bloqueado(contato(NOME,_))),
-	retract(contato(NOME,_));
+apagaContato(NOME,NUMERO):-
+	call(bloqueado(contato(NOME,NUMERO))), !,
+	retract(bloqueado(contato(NOME,NUMERO))),
+	retract(contato(NOME,NUMERO));
 	
-	call(favorito(contato(NOME,_))),!,
-	retract(favorito(contato(NOME,_))),
-	retract(contato(NOME,_));
+	call(favorito(contato(NOME,NUMERO))),!,
+	retract(favorito(contato(NOME,NUMERO))),
+	retract(contato(NOME,NUMERO));
 	
-	retract(contato(NOME,_)).
+	retract(contato(NOME,NUMERO)).
 	
 %-------------Método que altera o fato contato da base de dados ------------------
 
@@ -202,6 +204,9 @@ verificaContato(NOME):-
 
 	write("Contato nao existe!"), nl,nl,
 	executaMenu().
+
+exibirContatosNomeComum(NOME):-
+	forall(contato(NOME,Y), format('Nome: ~w~nNumero: ~w~n~n', [NOME,Y])).
 
 %------------Adicionar um contato aos favoritos-----------------------------------------------------
 adicionarAosFavoritos(NOME):-

--- a/agenda.pl
+++ b/agenda.pl
@@ -73,7 +73,7 @@ sw(8):-
 	write('Digite o nome do contato que deseja alterar: '),
 	read(NOMEANTIGO),nl,
 	verificaContato(NOMEANTIGO),
-	exibirContatosNomeComum(NOME),
+	exibirContatosNomeComum(NOMEANTIGO),
 	write('Digite o número para confirmar: '), read(NUMERO),
 	alteraContato(NOMEANTIGO, NUMERO),
 	executaMenu().
@@ -245,7 +245,7 @@ adicionarAosFavoritos(NOME,NUMERO):-
 removerFavorito(NOME,NUMERO):-
 	call(favorito(contato(NOME,NUMERO))), !,
 	apagaContato(NOME,NUMERO),
-	adicionaContato(NOME, NUMERO, CHAMADAS),
+	adicionaContato(NOME, NUMERO,_),
 	write("Contato removido da lista de favoritos!"),nl,nl,
 	executaMenu(), nl;
 


### PR DESCRIPTION
Se houvesse pessoas com mesmo nome e números diferentes na lista telefonica, o a opção de listar só mostrava, das pessoas de mesmo nome, a primeira encontrada e repetia o número para todas. Resolvi usando o forall().

Remove o contato correto após a confirmação do número.